### PR TITLE
Add required attribute homepage

### DIFF
--- a/ios/RNActionSheetIOS.podspec
+++ b/ios/RNActionSheetIOS.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNActionSheetIOS
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/welldsagl/react-native-action-sheet-ios"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "dev@welld.ch" }


### PR DESCRIPTION
The required attribute `homepage` was missing, causing a `pod install` error on `react-native` 0.60